### PR TITLE
fix link order in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS = -lncurses
 default: $(TARGET)
 
 $(TARGET): $(SRC)
-	$(CC) $(CFLAGS) $(SRC) -o $(TARGET)
+	$(CC) $(SRC) -o $(TARGET) $(CFLAGS)
 
 clean:
 	rm -f $(TARGET)

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ This is a text based diary, inspired by [khal](https://github.com/pimutils/khal)
     diary ~/.diary
     ```
 
-   Instead of this, you can also set the environment variable `DIARY_DIR`
-   to the desired directory. If both an argument and the environment
-   variable are given, the argument takes precedence.
+    By default this will copy the binary to /usr/local/bin. To use a different
+    path prefix, type `sudo make --PREFIX=/usr install` to use /usr/bin for example.
+    You can uninstall diary with `sudo make uninstall`.
 
    The text files in this folder will be named 'yyyy-mm-dd'.
 

--- a/diary.c
+++ b/diary.c
@@ -167,7 +167,7 @@ int main(int argc, char** argv) {
     if (argc < 2) {
         diary_dir = getenv("DIARY_DIR");
         if (diary_dir == NULL) {
-            fprintf(stderr, "The diary directory must ge given as command line "
+            fprintf(stderr, "The diary directory must be given as command line "
                             "argument or in the DIARY_DIR environment variable\n");
             return 1;
         }
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
     int prev_width = COLS - ASIDE_WIDTH - CAL_WIDTH;
     int prev_height = LINES - 1;
 
-    // init the current pad possition at the very end,
+    // init the current pad position at the very end,
     // such that the cursor is displayed top of screen
     int pad_pos = 9999999;
 


### PR DESCRIPTION
Changed makefile so that the -lncurses directive comes after object code with gcc.
This is because object files and libraries are linked in order in a single pass.
This solves compiling error with ubuntu ppa tests.

You can see the error log produced here for reference:
https://launchpadlibrarian.net/294648395/buildlog_ubuntu-trusty-amd64.diary_0.1-0_BUILDING.txt.gz