### PR TITLE
Adjust first day of week according to locale (#13)

### DIFF
--- a/diary.h
+++ b/diary.h
@@ -9,13 +9,14 @@
 #include <dirent.h>
 #include <ncurses.h>
 #include <locale.h>
+#include <langinfo.h>
 
 #define YEAR_RANGE 1
 #define CAL_WIDTH 21
 #define ASIDE_WIDTH 4
 #define MAX_MONTH_HEIGHT 6
 
-static const char* WEEKDAYS[] = {"Mo","Tu","We","Th","Fr","Sa","Su", NULL};
+static const char* WEEKDAYS[] = {"Su","Mo","Tu","We","Th","Fr","Sa"};
 
 void setup_cal_timeframe();
 void draw_wdays(WINDOW* head);


### PR DESCRIPTION
Since there currently is no option parsing, this commit adjust the
calendar solely according to locale, therefore this won't be portable if
the system doesn't use glibc.

In the future, even the system doesn't use glibc, user can use options,
for examples, `-s` (Sunday) and `-m` (Monday), to at least override the
default first day of week (`first_weekday`), currently set to Monday.

The detail of calculating the first day of week from locale setting,
`LC_TIME` section, can be read in locale(5) (read NOTES section first),
and util-linux's [cal.c][1] is a good example to read.

[1]: https://git.kernel.org/cgit/utils/util-linux/util-linux.git/tree/misc-utils/cal.c?h=stable/v2.28#n298