### PR TITLE
Basic diary entry viewer (alternative to #6), redraw on resize, and use Makefile implicit rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ ifeq ($(UNAME),FreeBSD)
 endif
 
 ifeq ($(UNAME),Linux)
-	LDLIBS = -lncursesw
+	CFLAGS += $(shell pkg-config --cflags ncursesw)
+	LDLIBS += $(shell pkg-config --libs   ncursesw)
 endif
 
 ifeq ($(UNAME),Darwin)

--- a/Makefile
+++ b/Makefile
@@ -5,25 +5,27 @@ BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 
 CC = gcc
 CFLAGS = -Wall
+CPPFLAGS += -D_XOPEN_SOURCE           # for wcwidth
+CPPFLAGS += -D_XOPEN_SOURCE_EXTENDED  # for waddnwstr
+
 UNAME = ${shell uname}
 
 ifeq ($(UNAME),FreeBSD)
-	LIBS = -lncurses
+	LDLIBS = -lncurses
 endif
 
 ifeq ($(UNAME),Linux)
-	LIBS = -lncursesw
+	LDLIBS = -lncursesw
 endif
 
 ifeq ($(UNAME),Darwin)
-	LIBS = -lncurses -framework CoreFoundation
+	LDLIBS = -lncurses -framework CoreFoundation
 endif
 
 
 default: $(TARGET)
 
 $(TARGET): $(SRC)
-	$(CC) $(SRC) -o $(TARGET) $(CFLAGS) $(LIBS)
 
 clean:
 	rm -f $(TARGET)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Note: for *BSD users run gmake.
 
     J         Go forward by 1 month
     K         Go backward by 1 month
+
+    pagedown  scroll down entry by half-page
+    pageup    scroll up entry by half-page
     ```
 
 ***

--- a/diary.h
+++ b/diary.h
@@ -15,7 +15,7 @@
 #include <time.h>
 #include <errno.h>
 #include <dirent.h>
-#include <ncursesw/ncurses.h>
+#include <ncurses.h>
 #include <locale.h>
 #include <langinfo.h>
 #include <sys/param.h>

--- a/diary.h
+++ b/diary.h
@@ -5,16 +5,20 @@
 #ifdef __MACH__
 	#include <CoreFoundation/CoreFoundation.h>
 #endif
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <wchar.h>
+#include <wctype.h>
 #include <time.h>
 #include <errno.h>
 #include <dirent.h>
-#include <ncurses.h>
+#include <ncursesw/ncurses.h>
 #include <locale.h>
 #include <langinfo.h>
+#include <sys/param.h>
 
 #define YEAR_RANGE 1
 #define CAL_WIDTH 21
@@ -29,7 +33,9 @@ void draw_calendar(WINDOW* number_pad, WINDOW* month_pad, char* diary_dir, size_
 void update_date(WINDOW* header);
 
 bool go_to(WINDOW* calendar, WINDOW* aside, time_t date, int* cur_pad_pos);
-void display_entry(const char* dir, size_t dir_size, const struct tm* date, WINDOW* win, int width);
+void read_entry(const char* dir, size_t dir_size, const struct tm* date,
+	        WINDOW* prev, int *y, int* x, int* height, int* width);
+void scroll_entry(WINDOW* prev, int* y, int* x, int height, int width);
 void edit_cmd(const char* dir, size_t dir_size, const struct tm* date, char** rcmd, size_t rcmd_size);
 
 bool date_has_entry(const char* dir, size_t dir_size, const struct tm* i);


### PR DESCRIPTION
The viewer has word-wrap (not optional), word-break on spaces and char columns = 2.

----

Few notes:

* The implementation is not idea, not tested with many languages, but roughly viewable. #6 might provide a better reading experiences since pagers like *less* has been very mature for long time.
* I only assigned two keys for half-page scroll, because I can't think of any good key candidates for actions like scrolling one line.
* There could be portability issues on those wide char functions.
* I implemented my own wrapping (like playing 12 Christmas puzzle games in a row) because I don't know if there is a library can wrap multilanguage text nicely. (perhaps there is a single-header library for that?)