### PR TITLE
Next/previous diary entry shortcuts (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Note: for *BSD users run gmake.
     h, left   go left by 1 day
     l, right  go right by 1 day
 
+    N         go to the previous diary entry
+    n         go to the next diary entry
+
     g         go to the first date
     G         go to the last date
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Note: for *BSD users run gmake.
 
     J         Go forward by 1 month
     K         Go backward by 1 month
+
+    q         quit the program
     ```
 
 ***

--- a/diary.c
+++ b/diary.c
@@ -576,6 +576,5 @@ int main(int argc, char** argv) {
     } while (ch != 'q');
 
     endwin();
-    system("clear");
     return 0;
 }

--- a/diary.c
+++ b/diary.c
@@ -256,6 +256,50 @@ void fpath(const char* dir, size_t dir_size, const struct tm* date, char** rpath
     strcat(*rpath, dstr);
 }
 
+/*
+ * Finds the most recent date before <current> that has a diary entry, or
+ * <current> itself if there is no previous diary entry
+ */
+struct tm find_previous_date(const struct tm current, const char* diary_dir, size_t diary_dir_size)
+{
+
+    time_t start = mktime(&cal_start);
+    struct tm it = current;
+    it.tm_mday--;
+
+    while (mktime(&it) >= start) {
+        if (date_has_entry(diary_dir, diary_dir_size, &it)) {
+            return it;
+        }
+
+        it.tm_mday--;
+    }
+
+    return current;
+}
+
+/*
+ * Finds the next date after <current> that has a diary entry, or <current>
+ * if there is no next diary entry
+ */
+struct tm find_next_date(const struct tm current, const char* diary_dir, size_t diary_dir_size)
+{
+
+    time_t end = mktime(&cal_end);
+    struct tm it = current;
+    it.tm_mday++;
+
+    while (mktime(&it) <= end) {
+        if (date_has_entry(diary_dir, diary_dir_size, &it)) {
+            return it;
+        }
+
+        it.tm_mday++;
+    }
+
+    return current;
+}
+
 int main(int argc, char** argv) {
     setlocale(LC_ALL, "");
     char diary_dir[80];
@@ -502,6 +546,16 @@ int main(int argc, char** argv) {
                     prefresh(cal, pad_pos, 0, 1, ASIDE_WIDTH,
                              LINES - 1, ASIDE_WIDTH + CAL_WIDTH);
                 }
+                break;
+            // Move to the previous diary entry
+            case 'N':
+                new_date = find_previous_date(new_date, diary_dir, strlen(diary_dir));
+                mv_valid = go_to(cal, aside, mktime(&new_date), &pad_pos);
+                break;
+            // Move to the next diary entry
+            case 'n':
+                new_date = find_next_date(new_date, diary_dir, strlen(diary_dir));
+                mv_valid = go_to(cal, aside, mktime(&new_date), &pad_pos);
                 break;
         }
 

--- a/diary.h
+++ b/diary.h
@@ -25,7 +25,7 @@ static const char* WEEKDAYS[] = {"Su","Mo","Tu","We","Th","Fr","Sa"};
 
 void setup_cal_timeframe();
 void draw_wdays(WINDOW* head);
-void draw_calendar(WINDOW* number_pad, WINDOW* month_pad, char* diary_dir, size_t diary_dir_size);
+void draw_calendar(WINDOW* number_pad, WINDOW* month_pad, const char* diary_dir, size_t diary_dir_size);
 void update_date(WINDOW* header);
 
 bool go_to(WINDOW* calendar, WINDOW* aside, time_t date, int* cur_pad_pos);


### PR DESCRIPTION
Here I've made an implementation of the feature I requested in Issue #14 : Jumping to the next/previous diary entry with <kbd>n</kbd>/<kbd>N</kbd> (like vim search).

I've gone for the simpler implementation of looping over dates until there is one where a diary entry exists. As already anticipated in the discussion on #14 , jumping between entries takes a negligible amount of time, even if the entries are 1.5 years apart.

The [concerns raised by livibetter](https://github.com/in0rdr/diary/issues/14#issuecomment-267760204), namely that there would be an infinite loop when the user is at (or past) the last/first entry are solved by just stopping the loop once the start/end of the calendar is reached, and keeping the cursor at the date it was before.

EDIT: Added two more commits. Now `strlen(diary_dir)` isn't computed over and over, which wasn't needed since the diary directory doesn't change at runtime.