### PR TITLE
Makefile: use DESTDIR in MANDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SRC = diary.c
 PREFIX ?= /usr/local
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 
-MANDIR := $(PREFIX)/share/man
+MANDIR := $(DESTDIR)$(PREFIX)/share/man
 MAN1 = diary.1
 
 CC = gcc


### PR DESCRIPTION
without `DESTDIR`, the scripts generating the rpm file try to install to the root filesystem instead of the fake root.